### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Marcello_deSales@intuit.com
 
 RUN apt-get -qq update && apt-get -qq install openjdk-7-jdk maven wget
 
-RUN wget -O /tmp/nexus-latest-bundle.tar.gz http://download.sonatype.com/nexus/oss/nexus-2.10.0-02-bundle.tar.gz
+RUN wget -O /tmp/nexus-latest-bundle.tar.gz http://download.sonatype.com/nexus/oss/nexus-latest-bundle.tar.gz
 
 RUN mkdir -p /opt/sonatype-nexus /opt/sonatype-work /opt/sonatype-work/nexus && \
     tar -zxvf /tmp/nexus-latest-bundle.tar.gz -C /opt/sonatype-nexus --strip-components=1 && \


### PR DESCRIPTION
Updating Nexus URL to pull latest version of Nexus 2 instead of a pinned version. Nexus 2.10 had a huge vulnerability in it, better to stay on the safe side :)
